### PR TITLE
Update README.md, fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A simple IoTeX Blockchain client implementation in C++ for embedded systems. Sup
 Compatible with some popular Arduino boards and Raspberry Pi/Unix environments.  
 
 ## Supported boards
-The SDK has been successfully tested on ESP32 and SAMD21 -based boards. ESP8266 will also work well for anything exchept smart contract calls: in this case we have experienced random crashes.
+The SDK has been successfully tested on ESP32 and SAMD21 -based boards. ESP8266 will also work well for anything except smart contract calls: in this case we have experienced random crashes.
 
 ## Documentation / Usage
 


### PR DESCRIPTION
Fixed a typo on line 6, col 114  - `excehpt` to `except`